### PR TITLE
Added prepareCloneUploadFromUrl that also fetches the metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,8 @@ A similar code chunk can be used to create new versions of an existing project, 
 
 ```js
 import * as hash from "hash-wasm";
-let existing = adb.getProjectMetadata(example_url, "test-public", { 
-    version: "base",
-    raw: true // get raw metadata for faithful re-upload.
- });
 
-let cloned = adb.prepareCloneUpload(existing);
+let cloned = adb.prepareCloneUploadFromUrl(example_url, "test-public", "base");
 let contents = cloned.metadata;
 let links = cloned.links;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifactdb",
-  "version": "0.2.0", 
+  "version": "0.3.0", 
   "description": "Javascript client for working with the ArtifactDB REST API.",
   "author": {
     "name": "Aaron Lun",

--- a/src/prepareCloneUpload.js
+++ b/src/prepareCloneUpload.js
@@ -1,9 +1,34 @@
+import { packId } from "./packId.js";
+import { getProjectMetadata } from "./getProjectMetadata.js";
+
+/**
+ * Fetch a project version's metadata and prepare a clone for upload.
+ * This is a convenience wrapper around {@linkcode getProjectMetadata} and {@linkcode prepareCloneUploadFromMetadata};
+ * see the latter for more details.
+ *
+ * @param {string} baseUrl - Base URL of the REST API.
+ * @param {string} project - Name of the project.
+ * @param {string} version - Version of interest.
+ * @param {Object} [options={}] - Optional parameters.
+ * @param {boolean} [options.stringify=true] - See {@linkcode prepareCloneUploadFromMetadata} for more details.
+ * @param {?function} [options.getFun=null] - See {@linkcode getProjectMetadata} for more details.
+ *
+ * @return {Object} Object containing values to be used for uploaded, see {@linkcode prepareCloneUploadFromMetadata} for more details.
+ */
+export async function prepareCloneUploadFromUrl(baseUrl, project, version, { stringify = true, getFun = null }) {
+    let metadata = await getProjectMetadata(baseUrl, project, { version: version, raw: true, getFun: getFun });
+    return prepareCloneUploadFromMetadata(project, version, metadata, { stringify });
+}
+
 /**
  * Prepare a clone of a project's version using its metadata.
  * This enables lightweight creation of new project versions without downloading each file and re-uploading them.
  * However, the same approach can be used to clone a project version under a completely different project name.
  *
- * @param {Array} metadata - Array of objects containing the metadata for a particular version of a project, typically from {@linkcode getProjectMetadata}.
+ * @param {string} project - Name of the project.
+ * @param {string} version - Version of interest.
+ * @param {Array} metadata - Array of objects containing the metadata for the specified version,
+ * typically generated from {@linkcode getProjectMetadata} with `raw = true`.
  * @param {Object} [options={}] - Optional parameters.
  * @param {boolean} [options.stringify=true] - Whether the metadata should be stringified in the return value.
  * Setting this to `false` is useful when further modifications to the metadata are to be performed.
@@ -12,24 +37,34 @@
  *
  * - `metadata`: object containing the JSON metadata for all files.
  *   Keys are the relative paths to the metadata files themselves (not the file artifacts), while values are the metadata objects for those files.
- *   This should used as `contents` in {@linkcode uploadProject} or {@linkcode initializeUpload} (after stringification if `stringify = false`).
+ *   This should used as `contents` in {@linkcode uploadProject} or {@linkcode uploadFiles} (after stringification if `stringify = false`).
  * - `links`: object containing the links to be created to the existing version of a project.
  *   Keys are the relative paths of the file artifacts to be linked from, while values are the ArtifactDB identifiers of the artifacts to be linked to.
- *   This should be used as `dedupLinkPaths` in {@linkcode uploadProject} or {@linkcode initializeUpload}.
+ *   This should be used as `dedupLinkPaths` in {@linkcode initializeUpload} or {@linkcode uploadProject} (via `initArgs`).
  */
-export function prepareCloneUpload(metadata, { stringify = true } = {}) {
+export function prepareCloneUploadFromMetadata(project, version, metadata, { stringify = true } = {}) {
     let contents = {};
     let links = {};
 
     for (const x of metadata) {
+        if ("_extra" in x) {
+            throw new Error("raw metadata should not contain an '_extra' property");
+        }
+
         let key = x.path;
-        if (!(key.endsWith(".json"))) {
-            links[key] = x["_extra"]["id"];
+        if (!key.endsWith(".json")) {
+            if (key in links) {
+                throw new Error("duplicate key '" + key + "' detected when creating links");
+            }
+            links[key] = packId(project, x.path, version);
             key += ".json";
         }
 
+        if (key in contents) {
+            throw new Error("duplicate key '" + key + "' detected for metadata");
+        }
+
         let basic = { ...x };
-        delete basic._extra;
         if (stringify) {
             contents[key] = JSON.stringify(basic);
         } else {

--- a/tests/prepareCloneUpload.test.js
+++ b/tests/prepareCloneUpload.test.js
@@ -3,11 +3,11 @@ import { exampleUrl, exampleId } from "./utils.js";
 import "isomorphic-fetch";
 
 test("prepareCloneUpload works correctly", async () => {
-    let res = await adb.getProjectMetadata(exampleUrl, "test-public", { version: "base" });
+    let res = await adb.getProjectMetadata(exampleUrl, "test-public", { version: "base", raw: true });
     expect(res.length > 0);
 
     {
-        let { metadata, links } = adb.prepareCloneUpload(res, { stringify: false });
+        let { metadata, links } = adb.prepareCloneUploadFromMetadata("test-public", "base", res, { stringify: false });
         expect(Object.keys(metadata).length).toBe(3);
         expect(Object.keys(links).length).toBe(3);
         expect(metadata["blah.txt.json"].path).toBe("blah.txt");
@@ -15,7 +15,23 @@ test("prepareCloneUpload works correctly", async () => {
     }
 
     {
-        let { metadata, links } = adb.prepareCloneUpload(res, { stringify: true });
+        let { metadata, links } = adb.prepareCloneUploadFromMetadata("test-public", "base", res, { stringify: true });
         expect(typeof metadata["blah.txt.json"]).toBe("string");
+
+        let yyy = await adb.prepareCloneUploadFromUrl(exampleUrl, "test-public", "base", { stringify: true });
+        expect(metadata).toEqual(yyy.metadata)
+        expect(links).toEqual(yyy.links)
     }
 }) 
+
+test("prepareCloneUpload fails correctly", async () => {
+    let res = await adb.getProjectMetadata(exampleUrl, "test-public", { version: "base" });
+    expect(res.length > 0);
+    expect(() => adb.prepareCloneUploadFromMetadata("test-public", "base", res, { stringify: false })).toThrow("_extra");
+
+    res = [ { "path": "foo.json" }, { "path": "foo.json" } ];
+    expect(() => adb.prepareCloneUploadFromMetadata("test-public", "base", res, { stringify: false })).toThrow("detected for metadata");
+
+    res = [ { "path": "foo" }, { "path": "foo" } ];
+    expect(() => adb.prepareCloneUploadFromMetadata("test-public", "base", res, { stringify: false })).toThrow("detected when creating links");
+})


### PR DESCRIPTION
This avoids problems from misspecification of the getProjectMetadata parameters; only advanced developers need to deal with that. The README instructions also simplify accordingly.

We also renamed prepareCloneUpload to prepareCloneUploadFromMetadata, which accepts a project/version pair as positional arguments. This is needed as the ID can't be inferred from _extra with raw metadata.